### PR TITLE
Set default value for placeName

### DIFF
--- a/dayone2notion.py
+++ b/dayone2notion.py
@@ -128,7 +128,7 @@ for source_file in args.files:
 
         if 'location' in entry:
             place = entry['location']
-            row.location = place['placeName']
+            row.location = place.get('placeName', '')
             row.longitude = place['longitude']
             row.latitude = place['latitude']
 


### PR DESCRIPTION
Sometimes there could be rows with location but without placeName like this

"location" : {
    "region" : {
      "center" : {
        "longitude" : 0,
        "latitude" : 0
      },
      "radius" : 75
    },